### PR TITLE
feat: Add ignore_exceptions to Client

### DIFF
--- a/cordcutter/__init__.py
+++ b/cordcutter/__init__.py
@@ -67,11 +67,12 @@ class Cordcutter(Generic[TClient]):
             return
 
         if self.ignore_exceptions:
-            for ignore_exception in self.ignore_exceptions:
-        if isinstance(exception, tuple(self.ignore_exceptions)):
-                    return
-                elif ignore_exception.__name__ in str(exception):
-                    return
+            if isinstance(exception, tuple(self.ignore_exceptions)):
+                return
+
+            original_exception: Exception | None = exception.__dict__.get("original")
+            if isinstance(original_exception, tuple(self.ignore_exceptions)):
+                return
 
         self.errors[interaction.application_command] += 1
 

--- a/cordcutter/__init__.py
+++ b/cordcutter/__init__.py
@@ -68,7 +68,7 @@ class Cordcutter(Generic[TClient]):
 
         if self.ignore_exceptions:
             for ignore_exception in self.ignore_exceptions:
-                if isinstance(exception, ignore_exception):
+        if isinstance(exception, tuple(self.ignore_exceptions)):
                     return
                 elif ignore_exception.__name__ in str(exception):
                     return

--- a/cordcutter/__init__.py
+++ b/cordcutter/__init__.py
@@ -68,7 +68,10 @@ class Cordcutter(Generic[TClient]):
 
         if self.ignore_exceptions:
             original_exception: Exception = getattr(exception, "original", exception)
+
             if isinstance(original_exception, tuple(self.ignore_exceptions)):
+                command: str = interaction.application_command.qualified_name
+                logger.warning("🔌 Ignoring exception: %s for command /%s", type(original_exception), command)
                 return
 
         self.errors[interaction.application_command] += 1

--- a/cordcutter/__init__.py
+++ b/cordcutter/__init__.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from datetime import timedelta
 from logging import getLogger
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, TypeVar, Type
 
 from nextcord import (
     ApplicationError,
@@ -14,6 +14,8 @@ from nextcord import (
     Interaction,
     SlashApplicationSubcommand,
 )
+
+from nextcord.ext.application_checks import ApplicationMissingPermissions
 
 TClient = TypeVar("TClient", bound="Client")
 
@@ -34,6 +36,7 @@ class Cordcutter(Generic[TClient]):
         *,
         threshold: int = 3,
         reset_after: timedelta | None = None,
+        ignore_exceptions: Iterable[Type[Exception]] | None = None
     ) -> None:
         """Create a new Cordcutter instance.
 
@@ -49,6 +52,8 @@ class Cordcutter(Generic[TClient]):
         self.threshold: int = threshold
         self.reset_after: timedelta = reset_after or timedelta(minutes=1)
         self.errors: defaultdict[ApplicationCommand, int] = defaultdict(int)
+        self.ignore_exceptions: Iterable[Type[Exception]] | None = ignore_exceptions
+
         self._on_tripped_call: Callback | None = None
 
     async def _on_application_command_error(
@@ -63,6 +68,13 @@ class Cordcutter(Generic[TClient]):
         if self.errors.get(interaction.application_command, 0) >= self.threshold:
             return
 
+        if self.ignore_exceptions:
+            for ignore_exception in self.ignore_exceptions:
+                if isinstance(exception, ignore_exception):
+                    return
+                elif ignore_exception.__name__ in str(exception):
+                    return
+
         self.errors[interaction.application_command] += 1
 
         if self.errors[interaction.application_command] >= self.threshold:
@@ -76,7 +88,7 @@ class Cordcutter(Generic[TClient]):
         """
         logger.warning("🔌 Breaker tripped for %s!", command.qualified_name)
 
-        original_callback: Any = command.callback  # pyright: reportUnknownMemberType=false
+        original_callback: Any = command.callback  # pyright: ignore[reportUnknownMemberType=false]
         command.callback = self._on_tripped_call
 
         asyncio.get_event_loop().call_later(

--- a/cordcutter/__init__.py
+++ b/cordcutter/__init__.py
@@ -44,6 +44,7 @@ class Cordcutter(Generic[TClient]):
             Defaults to 3.
             reset_after (timedelta, optional): After what time the command breaker should reset.
             Defaults to timedelta(minutes=1).
+            ignore_exceptions (Iterable): Exceptions that cordcutter should ignore
         """
         client.on_application_command_error = self._on_application_command_error
 

--- a/cordcutter/__init__.py
+++ b/cordcutter/__init__.py
@@ -67,10 +67,7 @@ class Cordcutter(Generic[TClient]):
             return
 
         if self.ignore_exceptions:
-            if isinstance(exception, tuple(self.ignore_exceptions)):
-                return
-
-            original_exception: Exception | None = exception.__dict__.get("original")
+            original_exception: Exception = getattr(exception, "original", exception)
             if isinstance(original_exception, tuple(self.ignore_exceptions)):
                 return
 

--- a/cordcutter/__init__.py
+++ b/cordcutter/__init__.py
@@ -15,8 +15,6 @@ from nextcord import (
     SlashApplicationSubcommand,
 )
 
-from nextcord.ext.application_checks import ApplicationMissingPermissions
-
 TClient = TypeVar("TClient", bound="Client")
 
 ApplicationCommand = SlashApplicationSubcommand | BaseApplicationCommand


### PR DESCRIPTION
## Problem
Currently CordCutter works on all exceptions, even the ones we handle with the `@command.error` decorator.
A new argument that can accept several exceptions will ignore typed exceptions.

## Additional context
```py
from nextcord import Client, Interaction
from nextcord.ext.application_checks import has_permissions, ApplicationMissingPermissions

from cordcutter import Cordcutter

client = Client()
cordcutter = Cordcutter(client)


@client.slash_command(name="test")
@has_permissions(manage_roles=True)
async def test_command(interaction: Interaction) -> None
    """
    Currently CordCutter will turn on for two people.
    For the person who has permissions but the command is broken 
    and for the person who does not have permissions to use this command.
    Because the command will raise an `ApplicationMissingPermission` exception.
    Ignoring individual exceptions will avoid this situation
    """

    raise RuntimeError("Shit. My command is broken :(")

@test_command.error
async def test_command_error(interaction, error):
    if isinstance(error, ApplicationMissingPermissions):
        await interaction.send("u dont have permissions")
```

